### PR TITLE
[Fix] Remove input file being in prompt twice

### DIFF
--- a/ciri/ciri_eng.py
+++ b/ciri/ciri_eng.py
@@ -36,14 +36,14 @@ def _ciri_eng(args, input_path: str, output_path: str, model=None, tokenizer=Non
 	print("[Ciri] Start")
 	print(f"[Ciri] Running for file {input_path}")
 	logger.debug(f"[Ciri] Running for file {input_path}")
-	input_file_content = Path(input_path).read_text()
+	input_file_content = ""
 	logger.debug(f"[Ciri] Input file content:\n{input_file_content}")
 	if args.validconfig_shot_num + args.misconfig_shot_num > 0:
 		shot_content = ShotSelection(
 			args,
 			input_file_content,
 		).select()
-		input_file_content = shot_content + input_file_content
+		input_file_content = shot_content
 	logger.debug(f"[Ciri] Shot+File to be queried:\n{input_file_content}")
 	config_file_content = Path(input_path).read_text()
 	if args.read_code:


### PR DESCRIPTION
Currently, the input file will appear twice in the prompt sent to the LLM, resulting in incorrectly identified errors due to it assuming config keys are being defined twice.